### PR TITLE
chore: remove Trivy security scanner from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,20 +219,6 @@ jobs:
         echo "Checking if our image exists:"
         docker inspect otel-example-java:pr-${{ github.event.pull_request.number }}
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.2
-      with:
-        image-ref: otel-example-java:pr-${{ github.event.pull_request.number }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        exit-code: '0'
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
-
   integration-test:
     needs: docker
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Removes \`aquasecurity/trivy-action\` from CI workflows due to the Trivy supply chain security incident
- Removes associated \`github/codeql-action/upload-sarif\` step (was only used to upload Trivy SARIF results)

## References

https://github.com/aquasecurity/trivy-action/issues/457

Made with [Cursor](https://cursor.com)